### PR TITLE
Added possibility to set the value to already added datarefs

### DIFF
--- a/pyprosim/pyprosim.py
+++ b/pyprosim/pyprosim.py
@@ -137,3 +137,17 @@ class PyProsim:
             "features": features,
             "licensee": info.Licensee,
         }
+
+    def set_dataref_value(self, dataref_name:str, dataref_value) -> None:
+        """Set dataref value ** Only works if it's been added previously
+        Attributes:
+        dataref_name -- Prosim dataref name
+        dataref_value -- New value for Prosim dataref
+        Return:
+        None
+        """
+        dataref = self.datarefs.get(dataref_name)
+        if dataref == None:
+            raise Exception("Value '" + dataref_name + "' has not been added prior to setting it")
+        
+        dataref.value = dataref_value


### PR DESCRIPTION
I've added a function "set_dataref_value" to the pyprosim class in order to set a value to an already added dataref.
The dataref object has a value attribute, when instantiated it checks for value changes and sends it to ProSim.

So it's just a matter of checking the datarefs array you already had in the class and if the dataref it's been added, just changing the value to it.